### PR TITLE
Update grammarkit version to circumvent 403 for jflex

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.jetbrains.grammarkit.tasks.*
 
 plugins {
     id "org.jetbrains.intellij" version "0.4.21"
-    id "org.jetbrains.grammarkit" version "2020.2"
+    id "org.jetbrains.grammarkit" version "2021.1.3"
     id "org.jetbrains.kotlin.jvm" version '1.5.31'
 }
 


### PR DESCRIPTION
The [request of Jetbrain's JFlex version 1.7.0-1](https://jetbrains.bintray.com/intellij-third-party-dependencies/org/jetbrains/intellij/deps/jflex/jflex/1.7.0-1/jflex-1.7.0-1.pom) results in a `403`. This issue does not occur with the newest version `2021.1.3` of Grammar-Kit.